### PR TITLE
Improve workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/wg-wizard
-          flavor: |
-            latest=${{ startsWith(github.ref, 'refs/tags/') }}
-          tags: |
-            type=ref,event=branch
-            type=pep440,pattern={{version}}
-            type=pep440,pattern={{major}}.{{minor}}
-            type=pep440,pattern={{major}}
       - name: Python package version (tag)
         if: github.ref_type == 'tag'
         run: echo 'PYTHON_PACKAGE_VERSION=${{ github.ref_name }}' >> ${GITHUB_ENV}
@@ -48,9 +36,18 @@ jobs:
           && "${POETRY_HOME}/bin/pip" install -U pip wheel setuptools \
           && "${POETRY_HOME}/bin/pip" install "poetry==${POETRY_VERSION}"
       - run: poetry version "${PYTHON_PACKAGE_VERSION}"
-      - name: Build and publish the PyPI package
-        if: github.ref_type == 'tag'
-        run: poetry publish --build --username __token__ --password "${PYPI_TOKEN}"
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/wg-wizard
+          flavor: |
+            latest=${{ startsWith(github.ref, 'refs/tags/') }}
+          tags: |
+            type=ref,event=branch
+            type=pep440,pattern={{version}}
+            type=pep440,pattern={{major}}.{{minor}}
+            type=pep440,pattern={{major}}
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
@@ -68,3 +65,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Build and publish the PyPI package
+        if: github.ref_type == 'tag'
+        run: poetry publish --build --username __token__ --password "${PYPI_TOKEN}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64, linux/arm64, linux/386, linux/arm/v7, linux/arm/v6
+          platforms: linux/amd64, linux/arm64, linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN set -x && DEBIAN_FRONTEND=noninteractive \
       if [ "${TARGETPLATFORM}" = 'linux/arm/v7' ]; then \
         # for poetry's dependencies if the wheels are not provided for the architecture
         apt-get install -y --no-install-recommends \
-          build-essential libssl-dev libffi-dev cargo; \
+          build-essential libssl-dev libffi-dev cargo git; \
       fi; \
     } \
     && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ ENV POETRY_VERSION=1.3.2
 ENV VIRTUAL_ENV=${HOME}/venv
 ENV POETRY_HOME=${HOME}/.poetry
 ENV PATH=${VIRTUAL_ENV}/bin:${POETRY_HOME}/bin:${PATH}
+# https://github.com/rust-lang/cargo/issues/10303
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 # install poetry
 RUN --mount=type=cache,target=${HOME}/.cache --mount=type=cache,target=${HOME}/.cargo set -x \

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,8 @@ Follow the instruction to create the config. Example output:
    If you want to allow the clients to access the internet via the relay server, you must provide the interface name you want to forward the internet traffic to. It's usually eth0 or wlan0. You can check it by executing `ip addr`. If you provide an interface name {interface}, the following rules will be added:
    - iptables -A FORWARD -i %i -o {interface} -j ACCEPT
    - iptables -A FORWARD -i {interface} -o %i -j ACCEPT
-   - iptables -t nat -A POSTROUTING -s {network} -o {interface} -j MASQUERADEInterface name for connecting to the internet []: eth0
+   - iptables -t nat -A POSTROUTING -s {network} -o {interface} -j MASQUERADE
+   Interface name for connecting to the internet []: eth0
    Do you want to allow the clients to connect with each other? If yes, a rule will be added: `iptables -A FORWARD -i %i -o %i -j ACCEPT` [Y/n]:
    Do you want to allow the clients to connect to any IPs on the relay server? If no, only the IP of the WireGuard interface can be connected, that is, the following rules will be added:
    - iptables -A INPUT -d {wg_server_interface_ip} -i %i -j ACCEPT

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,9 @@
 wg-wizard
 =========
 .. image:: https://github.com/ianlini/wg-wizard/actions/workflows/main.yml/badge.svg
-   :target: https://github.com/ianlini/wg-wizard/actions
+   :target: https://github.com/ianlini/wg-wizard/actions/workflows/main.yml
+.. image:: https://github.com/ianlini/wg-wizard/actions/workflows/release.yml/badge.svg
+   :target: https://github.com/ianlini/wg-wizard/actions/workflows/release.yml
 .. image:: https://img.shields.io/pypi/v/wg-wizard.svg
    :target: https://pypi.org/project/wg-wizard/
 .. image:: https://img.shields.io/pypi/l/wg-wizard.svg

--- a/src/wg_wizard/cli.py
+++ b/src/wg_wizard/cli.py
@@ -72,7 +72,7 @@ def main():
         "If you provide an interface name {interface}, the following rules will be added:\n"
         "- iptables -A FORWARD -i %i -o {interface} -j ACCEPT\n"
         "- iptables -A FORWARD -i {interface} -o %i -j ACCEPT\n"
-        "- iptables -t nat -A POSTROUTING -s {network} -o {interface} -j MASQUERADE"
+        "- iptables -t nat -A POSTROUTING -s {network} -o {interface} -j MASQUERADE\n"
         "Interface name for connecting to the internet"
     ),
     help="""


### PR DESCRIPTION
- Fix CI trigger bug and add manual trigger
- Fix Cargo issue when building cryptography
- Remove linux/386, linux/arm/v6 for improving build speed
- Reduce image size
  - Only install build tools for linux/arm/v7 in Dockerfile
    - linux/amd64: 303.32 MB -> 92.8 MB
    - linux/arm64: 271.33 MB -> 78.94 MB
  - Cache .cargo
    - linux/arm/v7: 359.48 MB -> 245 MB (still big because of those build tools; can be reduced if we use multi-stage build)
- Add badge for release
- Fix a typo for help message