### PR TITLE
Drop support for linux/arm/v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64, linux/arm64, linux/arm/v7
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,6 @@ RUN set -x && DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         wireguard-tools \
-    && { \
-      if [ "${TARGETPLATFORM}" = 'linux/arm/v7' ]; then \
-        # for poetry's dependencies if the wheels are not provided for the architecture
-        apt-get install -y --no-install-recommends \
-          build-essential libssl-dev libffi-dev cargo git; \
-      fi; \
-    } \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Because of a lot of issues when building `cryptography`, we have to drop support for linux/arm/v7. Please use v0.2.1 or upgrade your OS.